### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_NineAxesMotion
 version=1.1.2
 author=Bosch Sensortec GmbH
-maintainer=Arduino <swdev@arduino.org>
+maintainer=Arduino <info@arduino.cc>
 sentence=Arduino 9 Axes Motion Shield Library
 paragraph=Allows controlling each motion sensor of the 9 Axes Motion Shield.
 category=Sensors


### PR DESCRIPTION
Maintainer is changed from `Arduino <swdev@arduino.org>` to `Arduino <info@arduino.cc>` within the `library.properties` file. 